### PR TITLE
Make the Uri type hashable.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpe"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ken Johnson <ken.johnso93@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/johnso51/cpe-rs"
 
 [dependencies]
 thiserror = "1.0"
-language-tags = "0.2"
+language-tags = "0.3"
 percent-encoding = "2.1"
 derive_builder = "0.9"
 regex = "1.4"

--- a/src/cpe.rs
+++ b/src/cpe.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 /// CPE Language value
 ///
 /// May be "ANY", or a valid RFC-5646 language tag.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Language {
     Any,
     Language(LanguageTag),

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ pub enum CpeError {
     LanguageError {
         #[from]
         #[source]
-        source: language_tags::Error,
+        source: language_tags::ParseError,
     },
     #[error("Invalid CPE type \"{value}\"")]
     InvalidCpeType { value: String },

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -350,7 +350,7 @@ impl<'a> From<&Wfn<'a>> for Uri<'a> {
 
 /// Owned copy of a URI for when lifetimes do not permit borrowing
 /// from the input.
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Hash)]
 pub struct OwnedUri {
     pub(crate) part: CpeType,
     pub(crate) vendor: OwnedComponent,

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -73,7 +73,7 @@ macro_rules! uri {
 /// assert_eq!(format!("{:0}", uri), "cpe:/a:foo!".to_owned());
 /// assert_eq!(format!("{:#0}", uri), "cpe:/a:foo%21".to_owned());
 ///```
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Hash)]
 pub struct Uri<'a> {
     pub(crate) part: CpeType,
     pub(crate) vendor: Component<'a>,

--- a/src/wfn.rs
+++ b/src/wfn.rs
@@ -122,7 +122,7 @@ macro_rules! wfn {
 /// assert_eq!(format!("{:0}", wfn), "wfn:[part=a,vendor=foo!]".to_owned());
 /// assert_eq!(format!("{:#0}", wfn), "wfn:[part=a,vendor=foo\\!]".to_owned());
 ///```
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Hash)]
 pub struct Wfn<'a> {
     pub(crate) part: CpeType,
     pub(crate) vendor: Component<'a>,
@@ -426,6 +426,7 @@ impl<'a> From<&Uri<'a>> for Wfn<'a> {
 
 /// Owned copy of a Wfn for when lifetimes do not permit borrowing
 /// from the input.
+#[derive(Hash)]
 pub struct OwnedWfn {
     pub(crate) part: CpeType,
     pub(crate) vendor: OwnedComponent,


### PR DESCRIPTION
This requires updating to language_tags version 3, which itself requires some small changes to the error handling. The language_tags::Error trait is now private, so instead use the language_tags::ParseError type directly.