### PR TITLE
Add FromStr impls for the Owned Variants

### DIFF
--- a/src/uri.rs
+++ b/src/uri.rs
@@ -25,6 +25,7 @@ use crate::wfn::{OwnedWfn, Wfn};
 use std::fmt;
 
 use std::convert::TryFrom;
+use std::str::FromStr;
 
 /// Helper macro to create a `Uri` from literal values.
 #[macro_export]
@@ -417,6 +418,14 @@ impl fmt::Display for OwnedUri {
             write!(f, ":{:#}", self.language)?;
         }
         Ok(())
+    }
+}
+
+impl FromStr for OwnedUri {
+    type Err = CpeError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Uri::parse(s).map(|i| i.to_owned())
     }
 }
 

--- a/src/wfn.rs
+++ b/src/wfn.rs
@@ -44,6 +44,7 @@
 
 use std::convert::TryFrom;
 use std::fmt;
+use std::str::FromStr;
 
 use crate::component::{Component, OwnedComponent};
 use crate::cpe::{CpeType, Language};
@@ -474,6 +475,14 @@ impl fmt::Display for OwnedWfn {
         write_field!(target_hw);
         write_field!(other);
         write!(f, "]")
+    }
+}
+
+impl FromStr for OwnedWfn {
+    type Err = CpeError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Wfn::parse(s).map(|i| i.to_owned())
     }
 }
 


### PR DESCRIPTION
Similar to #2, I have a use case where having `FromStr` implementations would be useful with the CPE data types.

The `parse()` functions on `Uri` and `Wfn` types provide a mechanism to parse valid CPE's from `&str`'s that will at live least as long as the `Uri<'a>` or `Wfn<'a>`. The `std::str::FromStr` trait does not allow this constraint of the input `&str` lifetime. Add a `FromStr` impl to the `OwnedWfn` and `OwndUri` structs that calls the base `parse()` implementations, then converts to the owned CPE to decouple from the input `&str` lifetime.