### PR TITLE
Add permissive CPE URI validation and cargo clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpe"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Ken Johnson <ken.johnso93@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ lazy_static = "1.4"
 [features]
 default = ["display"]
 display = []
+permissive_encoding = []

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ with implementations conforming to [CPE22] and possibly prior releases as well.
 
 Source: [\[CPE23-N\]](#\[2\])
 
+As a special exception to section 5.4 of the CPE standard, the `permissive_encoding` feature will
+permit URIs with `\`, `+`, and `!` characters. While not intended for long term operation, this
+feature provides a method to find more egregious issues in CPE URIs while developers fix encoding
+issues for these commonly used characters.
+
 ## References
 
 ###### \[1\]

--- a/src/component.rs
+++ b/src/component.rs
@@ -58,7 +58,7 @@ impl<'a> Component<'a> {
     pub fn new(val: &'a str) -> Self {
         if val == "-" || val == "NA" {
             Self::NotApplicable
-        } else if val == "" || val == "ANY" {
+        } else if val.is_empty() || val == "ANY" {
             Self::Any
         } else {
             Self::Value(Cow::Borrowed(val))
@@ -68,7 +68,7 @@ impl<'a> Component<'a> {
     pub fn new_string(val: String) -> Self {
         if val == "-" || val == "NA" {
             Self::NotApplicable
-        } else if val == "" || val == "ANY" {
+        } else if val.is_empty() || val == "ANY" {
             Self::Any
         } else {
             Self::Value(Cow::Owned(val))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 //! A Rust crate for working with CPE 2.3 Well Formed Named and CPE 2.2 URI strings.
+//!
+//! Request the `permissive_encoding` feature to allow literal `!`, `+`, and `\` characters in CPE
+//! URIs. This is a violation of the CPE 2.2 specification, but provides some clemency for
+//! developers while still flagging the most egregious errors.
 pub mod builder;
 pub mod component;
 pub mod cpe;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -15,12 +15,12 @@ pub fn validate_wfn_attribute(value: &str) -> bool {
     value != "*" && WFN_REGEX.is_match(value)
 }
 
-pub fn parse_wfn_attribute<'a>(value: &'a str) -> Result<Component<'a>> {
+pub fn parse_wfn_attribute(value: &str) -> Result<Component> {
     if value == "ANY" {
         Ok(Component::Any)
     } else if value == "NA" {
         Ok(Component::NotApplicable)
-    } else if validate_wfn_attribute(&value) {
+    } else if validate_wfn_attribute(value) {
         let value = WFN_REPLACE.replace_all(value, "$esc");
         Ok(Component::Value(value))
     } else {
@@ -38,7 +38,7 @@ pub fn encode_wfn_attribute<'a>(value: &'a Component<'a>) -> Cow<'a, str> {
     match value {
         Component::Any => Cow::Borrowed("ANY"),
         Component::NotApplicable => Cow::Borrowed("NA"),
-        Component::Value(val) => WFN_ENCODE_REPLACE.replace_all(&val, r"\$esc"),
+        Component::Value(val) => WFN_ENCODE_REPLACE.replace_all(val, r"\$esc"),
     }
 }
 
@@ -79,19 +79,19 @@ pub fn encode_uri_attribute<'a>(value: &'a Component<'a>) -> Cow<'a, str> {
             if val.contains('?') || val.contains('*') {
                 Cow::Owned(
                     percent_encoding::utf8_percent_encode(
-                        &val.replace("?", "%01").replace("*", "%02"),
+                        &val.replace('?', "%01").replace('*', "%02"),
                         &RESERVED,
                     )
                     .to_string(),
                 )
             } else {
-                percent_encoding::utf8_percent_encode(&val, &RESERVED).into()
+                percent_encoding::utf8_percent_encode(val, &RESERVED).into()
             }
         }
     }
 }
 
-pub fn parse_uri_attribute<'a>(value: &'a str) -> Result<Component<'a>> {
+pub fn parse_uri_attribute(value: &str) -> Result<Component> {
     if value.is_empty() {
         Ok(Component::Any)
     } else if value == "-" {
@@ -122,7 +122,7 @@ pub fn parse_uri_attribute<'a>(value: &'a str) -> Result<Component<'a>> {
     }
 }
 
-pub fn parse_packed_uri_attribute<'a>(value: &'a str) -> Result<PackedComponents<'a>> {
+pub fn parse_packed_uri_attribute(value: &str) -> Result<PackedComponents> {
     if value.starts_with('~') {
         let parts = value.split('~').collect::<Vec<_>>();
         if parts.len() != 6 {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -30,8 +30,14 @@ pub fn parse_wfn_attribute(value: &str) -> Result<Component> {
     }
 }
 
+#[cfg(not(feature="permissive_encoding"))]
 pub fn validate_uri_attribute(value: &str) -> bool {
     URI_REGEX.is_match(value)
+}
+
+#[cfg(feature="permissive_encoding")]
+pub fn validate_uri_attribute(value: &str) -> bool {
+    PERMISSIVE_URI_REGEX.is_match(value)
 }
 
 pub fn encode_wfn_attribute<'a>(value: &'a Component<'a>) -> Cow<'a, str> {
@@ -172,6 +178,10 @@ lazy_static! {
 
     static ref WFN_ENCODE_REPLACE: Regex = Regex::new(r##"(?P<esc>[\\!"#$%&'()+,./:;<=>@\[\]^`{|}~\-?*])"##).unwrap();
 
+
+    static ref PERMISSIVE_URI_REGEX: Regex = Regex::new(concat!(
+        r"^(?:(?:%01)+|%02)?(?:[\w\-._+]|(:?\\?(?:\+|!))?|%(?:2[1-9a-f]|3[a-f]|[46]0|[57][b-e]))*(?:(?:%01)+|%02)?$"
+    )).unwrap();
 
     static ref URI_REGEX: Regex = Regex::new(concat!(
         r"^(?:(?:%01)+|%02)?(?:[\w\-._]|%(?:2[1-9a-f]|3[a-f]|[46]0|[57][b-e]))*(?:(?:%01)+|%02)?$"

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -254,12 +254,13 @@ impl<'a> Uri<'a> {
             uri
         };
 
-        let uri = if uri.starts_with("cpe:/") {
-            &uri[5..]
-        } else {
-            return Err(CpeError::InvalidPrefix {
-                value: uri.to_owned(),
-            });
+        let uri = match uri.strip_prefix("cpe:/") {
+            Some(u) => u,
+            None => {
+                return Err(CpeError::InvalidPrefix {
+                    value: uri.to_owned(),
+                })
+            }
         };
 
         let mut components = uri.split(':');
@@ -287,7 +288,7 @@ impl<'a> Uri<'a> {
 
         let (edition, sw_edition, target_sw, target_hw, other) = components
             .next()
-            .map(|edition| parse_packed_uri_attribute(edition))
+            .map(parse_packed_uri_attribute)
             .transpose()?
             .unwrap_or_default();
 


### PR DESCRIPTION
As per the title. This provides the `permissive_encoding` feature to permit literal `!`, `+`, and `\` characters in CPE URIs. I also did some cargo clippy fixes while here--presumably these are just new / improved lints since anyone last looked at this code.

Interesting side note: `lazy_static!` does not seem to permit `#[cfg]` annotations on its items.